### PR TITLE
Fix typo + add "Go to Bluesky" button

### DIFF
--- a/app/screens/done-migration.tsx
+++ b/app/screens/done-migration.tsx
@@ -6,6 +6,11 @@ import type { ScreenProps } from "~/util/stages";
 export default function DoneMigrationScreen({
   state,
 }: ScreenProps): ReactElement {
+
+  const goToBluesky = () => {
+    window.location.href = "https://bsky.app";
+  }
+
   return (
     <>
       <VStack mb="5">
@@ -39,7 +44,7 @@ export default function DoneMigrationScreen({
         ) : (
           <>
             <Heading size="3xl" letterSpacing="tight">
-              New account creatd!
+              New account created!
             </Heading>
             <Text fontSize="md" textAlign={"justify"}>
               You may now login via the Bluesky app using the provided
@@ -47,6 +52,9 @@ export default function DoneMigrationScreen({
               enter: <br />
               <strong>https://northsky.social</strong>
             </Text>
+            <Button size="lg" onClick={goToBluesky}>
+              Login via the Bluesky app
+            </Button>
           </>
         )}
       </VStack>


### PR DESCRIPTION
## Description

This PR makes two small changes to the final page of the "Create account" flow:
- Fix a typo on the page title
- Add a button so the user is redirected to the Bluesky app

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<img width="1231" height="585" alt="Screenshot 2025-10-10 at 5 07 16 PM" src="https://github.com/user-attachments/assets/c6a1ecea-edbb-426a-8a23-147001552590" />

This is the screen that this fix modifies (before).

## Type of Change
<!-- Mark relevant options with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements