### PR TITLE
Improve public-facing error message for create account errors

### DIFF
--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -316,7 +316,17 @@ export async function createDestAccount(
     console.log("Migrated account creation status: ", createAccountRes.status);
 
     if (!createAccountRes.ok) {
-      throw new CreateAccountError(createAccountRes.statusText);
+      let errorMessage: string;
+
+      try {
+        const errorData = await createAccountRes.json<{ message?: string }>();
+        errorMessage = errorData.message ?? createAccountRes.statusText;
+      } catch {
+        errorMessage = createAccountRes.statusText;
+      }
+
+      console.log(`Failed to create migrated account: ${errorMessage}`);
+      throw new CreateAccountError(errorMessage);
     }
     console.log(`Migrating dest account created successfully with invite code: ${inviteCode}`);
     await sendDiscordMessage(`Migrating account [**${handle_dest}**](<https://bsky.app/profile/${did}>) (${did}) created successfully with invite code: ${inviteCode} (migration in progress)`);


### PR DESCRIPTION
## Description

When create account fails on a migration, instead of just returning the status error text (e.g. "Internal server error"), attempt to read the error message from the back-end.

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<!-- Add before/after screenshots, GIFs, or key log snippets -->

## Type of Change
<!-- Mark relevant options with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements