### PR TITLE
Centralize 2FA logic to fix bug on Resume Migration

### DIFF
--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -12,7 +12,7 @@ import { redisGet, redisSet } from "~/util/redis";
 
 const HEALTH_CHECK_CACHE_KEY = "pds:health";
 const HEALTH_CHECK_CACHE_TTL_SECONDS = 10;
-const HEALTH_CHECK_TIMEOUT_MS = 2500;
+const HEALTH_CHECK_TIMEOUT_MS = 5000;
 const HEALTH_CHECK_FAILURE_COUNT_KEY = "pds:health:failures";
 const HEALTH_CHECK_FAILURE_THRESHOLD = 4;
 const HEALTH_CHECK_FAILURE_TTL_SECONDS = 90;
@@ -66,7 +66,7 @@ export async function checkPdsHealth(): Promise<boolean> {
     logger.error(`PDS health check failed with status ${response.status}`);
     return await handleHealthCheckFailure();
   } catch (error) {
-    logger.error("PDS health check failed due to network error", error);
+    logger.warn("PDS health check failed due to network error", error);
     return await handleHealthCheckFailure();
   }
 }

--- a/app/util/logger.ts
+++ b/app/util/logger.ts
@@ -35,6 +35,9 @@ export const logger = {
   info: (...args: any[]) => {
     if (enabled("info")) console.info(...args);
   },
+  warn: (...args: any[]) => {
+    if (enabled("info")) console.warn(...args);
+  },
   error: (...args: any[]) => {
     if (enabled("error")) console.error(...args);
   },

--- a/app/util/process-state.ts
+++ b/app/util/process-state.ts
@@ -22,6 +22,82 @@ import { sendDiscordMessage } from "./discord";
 import { processBackgroundJobStage } from "./jobs";
 
 /**
+ * Handles origin PDS login with 2FA support.
+ * On first attempt, reads credentials from form and saves to session.
+ * On 2FA retry, retrieves credentials from session instead.
+ *
+ * @returns login result on success, or null if 2FA is required (session flashed with error)
+ */
+const handleOriginLoginWith2FA = async (
+  session: Session<SessionData, SessionFlashData>,
+  data: FormData,
+  context: string
+): Promise<{
+  token_origin: string;
+  email: string | undefined;
+  did: string;
+  atp_origin_session: unknown;
+} | null> => {
+  const is2faAttempt = session.get("require_2fa_code") ?? false;
+  console.log(`User attempting 2FA login for ${context}? ${is2faAttempt}`);
+
+  let pds_origin = (data.get("pds") as string) ?? "https://bsky.social";
+  let handle_origin = data.get("bsky-handle") as string;
+  let password_origin = (data.get("bsky-password") as string) ?? "";
+
+  if (is2faAttempt) {
+    pds_origin = session.get("pds_origin") ?? pds_origin;
+    handle_origin = session.get("handle_origin") ?? handle_origin;
+    password_origin = session.get("password_origin") ?? password_origin;
+
+    console.log("User session retrieved from first sign-in attempt, handle: ", handle_origin);
+  } else {
+    console.log("User session before update, handle: ", session.get("handle_origin") ?? "not set");
+
+    session.set("pds_origin", pds_origin);
+    session.set("handle_origin", handle_origin);
+    session.set("password_origin", password_origin);
+
+    console.log("User session saved from form, handle: ", handle_origin);
+  }
+
+  try {
+    console.log(`Attempting to log in user to origin for ${context}. Handle: `, handle_origin);
+    const result = await loginOrigin({
+      pds_origin,
+      handle_origin,
+      password_origin,
+      authFactorToken: (data.get("2fa_code") as string) ?? undefined,
+    });
+
+    session.set("email", result.email);
+    session.set("token_origin", result.token_origin);
+    session.set("did", result.did);
+    session.set("atp_origin_session", result.atp_origin_session);
+
+    // At this point, we no longer need the origin password
+    session.set("password_origin", undefined);
+
+    return result;
+  } catch (e) {
+    console.log(`Error during origin login for ${context}: `, e);
+
+    if (e instanceof AuthFactorTokenRequiredError) {
+      console.log("2FA code required for origin login, prompting user to enter 2FA code");
+      session.set("require_2fa_code", true);
+      session.flash(
+        "error",
+        "Please check your email for your login code and enter it below"
+      );
+      session.flash("errorType", "Expected");
+      return null;
+    }
+
+    throw e;
+  }
+};
+
+/**
  * Takes the form data, runs any side-effect actions,
  * sets new session data, return redirect.
  * @param session
@@ -128,73 +204,22 @@ export const processState = async (
       }
 
       case STAGES.ORIGIN_PDS_LOGIN: {
-        // If at this point we know the user requires a 2FA code, that means
-        // this stage as already submitted once so we already have PDS/handle/password.
-        // In that case, we don't read from form or save to session and just retrieve.
-        // Otherwise (first attempt or no 2FA), read from form and save to session.
-        const is2faAttempt = session.get("require_2fa_code") ?? false;
-        console.log("User attempting 2FA login? " + is2faAttempt);
+        const loginResult = await handleOriginLoginWith2FA(session, data, "origin login");
 
-        let pds_origin = (data.get("pds") as string) ?? "https://bsky.social";
-        let handle_origin = data.get("bsky-handle") as string;
-        let password_origin = (data.get("bsky-password") as string) ?? "";
-
-        if (is2faAttempt) {
-          pds_origin = session.get("pds_origin") ?? pds_origin;
-          handle_origin = session.get("handle_origin") ?? handle_origin;
-          password_origin = session.get("password_origin") ?? password_origin;
-
-          console.log("User session retrieved from first sign-in attempt, handle: ", handle_origin);
-        } else {
-          console.log("User session before update, handle: ", session.get("handle_origin") ?? "not set");
-
-          session.set("pds_origin", pds_origin);
-          session.set("handle_origin", handle_origin);
-          session.set("password_origin", password_origin);
-
-          console.log("User session saved from form, handle: ", handle_origin);
-        }
-
-        try {
-          const { token_origin, email, did, atp_origin_session } =
-            await loginOrigin({
-              pds_origin,
-              handle_origin,
-              password_origin,
-              authFactorToken: (data.get("2fa_code") as string) ?? undefined,
-            });
-
-          session.set("email", email);
-          session.set("token_origin", token_origin);
-          session.set("did", did);
-          session.set("atp_origin_session", atp_origin_session);
-
-          // At this point, we no longer need the origin password
-          session.set("password_origin", undefined);
-
-          const did_exists_in_dest = await checkIfDidExistsInDest(
-            did,
-            session.get("pds_dest") ?? "https://northsky.social",
-          );
-          session.set("did_exists_in_dest", did_exists_in_dest);
-
-          console.log(`Origin login successful! DID ${did}, exists in destination PDS: ${did_exists_in_dest}`);
+        if (!loginResult) {
+          // 2FA required, session already flashed with error
           break;
-        } catch (e) {
-          console.log("Error during origin login: ", e);
-
-          if (e instanceof AuthFactorTokenRequiredError) {
-            session.set("require_2fa_code", true);
-            session.flash(
-              "error",
-              "Please check your email for your login code and enter it below"
-            );
-            session.flash("errorType", "Expected");
-            break;
-          }
-
-          throw e;
         }
+
+        const { did } = loginResult;
+        const did_exists_in_dest = await checkIfDidExistsInDest(
+          did,
+          session.get("pds_dest") ?? "https://northsky.social",
+        );
+        session.set("did_exists_in_dest", did_exists_in_dest);
+
+        console.log(`Origin login successful! DID ${did}, exists in destination PDS: ${did_exists_in_dest}`);
+        break;
       }
 
       case STAGES.CREATE_DEST_ACCOUNT: {
@@ -307,46 +332,11 @@ export const processState = async (
 
       case STAGES.MISSING_BLOBS_LOGIN:
       case STAGES.RESUME_MIGRATION: {
-        try {
-          //Get origin, handle and password from form, immediately save to session
-          const pds_origin =
-            (data.get("pds") as string) ?? "https://bsky.social";
-          session.set("pds_origin", pds_origin);
+        const loginResult = await handleOriginLoginWith2FA(session, data, "resume/missing blobs");
 
-          const handle_origin = data.get("bsky-handle") as string;
-          session.set("handle_origin", handle_origin);
-
-          const password_origin = (data.get("bsky-password") as string) ?? "";
-          session.set("password_origin", password_origin);
-
-          console.log("Attempting to log in user to origin for resume/missing blobs journey. Handle: ", handle_origin);
-          const { token_origin, email, did, atp_origin_session } =
-            await loginOrigin({
-              pds_origin,
-              handle_origin,
-              password_origin,
-              authFactorToken: (data.get("2fa_code") as string) ?? undefined,
-            });
-
-          session.set("email", email);
-          session.set("token_origin", token_origin);
-          session.set("did", did);
-          session.set("atp_origin_session", atp_origin_session);
-
-          // At this point, we no longer need the origin password
-          session.set("password_origin", undefined);
-        } catch (e) {
-          if (e instanceof AuthFactorTokenRequiredError) {
-            console.log("2FA required for resume/missing blobs login attempt, prompting user for 2FA code");
-            session.set("require_2fa_code", true);
-            session.flash(
-              "error",
-              "Please check your email for your login code and enter it below"
-            );
-            session.flash("errorType", "Expected");
-            break;
-          }
-          throw e;
+        if (!loginResult) {
+          // 2FA required, session already flashed with error
+          break;
         }
 
         //Get dest handle and password from form

--- a/app/util/process-state.ts
+++ b/app/util/process-state.ts
@@ -332,7 +332,9 @@ export const processState = async (
 
       case STAGES.MISSING_BLOBS_LOGIN:
       case STAGES.RESUME_MIGRATION: {
-        const loginResult = await handleOriginLoginWith2FA(session, data, "resume/missing blobs");
+        const isMissingBlobsJourney = state.do_journey === "missing-blobs";
+        const journeyContext = isMissingBlobsJourney ? "missing blobs recovery" : "migration resume";
+        const loginResult = await handleOriginLoginWith2FA(session, data, journeyContext);
 
         if (!loginResult) {
           // 2FA required, session already flashed with error
@@ -346,7 +348,7 @@ export const processState = async (
         // Save dest handle to form in case it's changed somehow
         session.set("handle_dest", handle_dest);
 
-        console.log("Attempting to log in user to destination for resume/missing blobs journey. Handle: ", handle_dest);
+        console.log(`Attempting to log in user to destination for ${journeyContext}. Handle: ${handle_dest}`);
         const { token_dest, atp_dest_session } = await loginDest({
           pds_dest: state.pds_dest ?? "https://northsky.social",
           handle_dest,
@@ -357,8 +359,6 @@ export const processState = async (
         session.set("atp_dest_session", atp_dest_session);
 
         const did = session.get("did") ?? "unknown DID";
-
-        const isMissingBlobsJourney = state.do_journey === "missing-blobs";
 
         if (isMissingBlobsJourney) {
           await sendDiscordMessage(`Missing blobs recovery started for account [**${handle_dest}**](<https://bsky.app/profile/${did}>) (${did})`);


### PR DESCRIPTION
## Description

Fixes a bug on session management and 2FA that was covered on migrate but not on resume.

Centralizes 2FA logic (and origin PDS login logic) into a single function shared by two places, to ensure these don't go out of sync.

Also minor tweak to PDS healthcheck timing.

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<!-- Add before/after screenshots, GIFs, or key log snippets -->

## Type of Change
<!-- Mark relevant options with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements