### PR TITLE
Catch PDS hostname errors on origin login

### DIFF
--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -10,7 +10,7 @@ import { logger } from "~/util/logger";
 import f from "~/util/mock-fetch";
 import type { AtpSessionData } from "@atproto/api/src/types";
 import { redisGet, redisSet } from "~/util/redis";
-import { isInvalidInviteCodeError, isRetryableServerError, XRPC_ERROR_MESSAGES } from "~/util/xrpc-errors";
+import { isInvalidInviteCodeError, isRetryableServerError, isUnreachableHostError, XRPC_ERROR_MESSAGES } from "~/util/xrpc-errors";
 
 const HEALTH_CHECK_CACHE_KEY = "pds:health";
 const HEALTH_CHECK_CACHE_TTL_SECONDS = 10;
@@ -184,11 +184,20 @@ export async function loginOrigin({
   }
 
   // Login to origin PDS
-  const { data: agentSessionData } = await origin_agent.login({
-    identifier: handle_origin,
-    password: password_origin,
-    authFactorToken,
-  });
+  let agentSessionData;
+  try {
+    ({ data: agentSessionData } = await origin_agent.login({
+      identifier: handle_origin,
+      password: password_origin,
+      authFactorToken,
+    }));
+  } catch (e) {
+    if (isUnreachableHostError(e)) {
+      logger.warn(`Unable to reach origin PDS at ${pds_origin}`, e);
+      throw new LoginError(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS);
+    }
+    throw e;
+  }
 
   const { did, email, accessJwt: token_origin } = agentSessionData;
 
@@ -800,10 +809,19 @@ export async function loginDest({
   }
 
   // Login to origin PDS
-  const { data: agentSessionData } = await dest_agent.login({
-    identifier: handle_dest,
-    password: password_dest,
-  });
+  let agentSessionData;
+  try {
+    ({ data: agentSessionData } = await dest_agent.login({
+      identifier: handle_dest,
+      password: password_dest,
+    }));
+  } catch (e) {
+    if (isUnreachableHostError(e)) {
+      logger.warn(`Unable to reach destination PDS at ${pds_dest}`, e);
+      throw new LoginError(XRPC_ERROR_MESSAGES.UNREACHABLE_DEST_PDS);
+    }
+    throw e;
+  }
 
   const { accessJwt: token_dest } = agentSessionData;
 

--- a/app/util/xrpc-errors.ts
+++ b/app/util/xrpc-errors.ts
@@ -24,6 +24,62 @@ export function isRetryableServerError(error: unknown): boolean {
 }
 
 /**
+ * Check if an error indicates a network-level failure reaching a PDS
+ * (e.g. invalid hostname, DNS failure, connection refused, TLS errors).
+ */
+export function isUnreachableHostError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === "string" && message.toLowerCase().includes("fetch failed")) {
+    return true;
+  }
+
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause && typeof cause === "object") {
+    const code = (cause as { code?: unknown }).code;
+    if (typeof code === "string" && UNREACHABLE_HOST_ERROR_CODES.has(code)) {
+      return true;
+    }
+
+    // Recurse through wrapped causes
+    if (isUnreachableHostError(cause)) {
+      return true;
+    }
+  }
+
+  const errors = (error as { errors?: unknown }).errors;
+  if (Array.isArray(errors)) {
+    for (const inner of errors) {
+      if (isUnreachableHostError(inner)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Network-level error codes (undici/DNS layer) that indicate the
+ * PDS hostname is unreachable.
+ */
+const UNREACHABLE_HOST_ERROR_CODES = new Set([
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+  "CERT_HAS_EXPIRED",
+]);
+
+/**
  * User-friendly error messages for XRPC errors during account creation.
  */
 export const XRPC_ERROR_MESSAGES = {
@@ -34,4 +90,10 @@ If you believe this is an error, please contact Support.",
   SERVER_ERROR:
     "We encountered a server error while creating your account on the Northsky PDS. \
 Please try again in a few minutes. If the problem persists, please contact Support.",
+  UNREACHABLE_ORIGIN_PDS:
+    "We couldn't reach your origin PDS. Please double-check the PDS URL you entered \
+and make sure the service is online, then try again.",
+  UNREACHABLE_DEST_PDS:
+    "We couldn't reach the Northsky PDS. Please try again in a few minutes. \
+If the problem persists, please contact Support.",
 } as const;

--- a/test/unit/xrpc-errors.test.ts
+++ b/test/unit/xrpc-errors.test.ts
@@ -2,6 +2,7 @@ import { XRPCError } from "@atproto/api";
 import {
   isInvalidInviteCodeError,
   isRetryableServerError,
+  isUnreachableHostError,
   XRPC_ERROR_MESSAGES,
 } from "~/util/xrpc-errors";
 
@@ -114,6 +115,67 @@ describe("xrpc-errors", () => {
       expect(XRPC_ERROR_MESSAGES.SERVER_ERROR).toContain("server error");
       expect(XRPC_ERROR_MESSAGES.SERVER_ERROR).toContain("try again");
       expect(XRPC_ERROR_MESSAGES.SERVER_ERROR).toContain("contact Support");
+    });
+
+    it("has UNREACHABLE_ORIGIN_PDS message", () => {
+      expect(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS).toContain("PDS");
+      expect(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS).toContain("try again");
+    });
+
+    it("has UNREACHABLE_DEST_PDS message", () => {
+      expect(XRPC_ERROR_MESSAGES.UNREACHABLE_DEST_PDS).toContain("Northsky PDS");
+    });
+  });
+
+  describe("isUnreachableHostError", () => {
+    it("returns true for TypeError with 'fetch failed' message", () => {
+      const error = new TypeError("fetch failed");
+      expect(isUnreachableHostError(error)).toBe(true);
+    });
+
+    it("returns true when cause has an unreachable code (ENOTFOUND)", () => {
+      const error = new Error("Some wrapped error");
+      (error as Error & { cause: unknown }).cause = { code: "ENOTFOUND" };
+      expect(isUnreachableHostError(error)).toBe(true);
+    });
+
+    it("returns true when cause has ECONNREFUSED code", () => {
+      const error = new Error("connection failure");
+      (error as Error & { cause: unknown }).cause = { code: "ECONNREFUSED" };
+      expect(isUnreachableHostError(error)).toBe(true);
+    });
+
+    it("returns true for nested causes", () => {
+      const error = new Error("outer");
+      (error as Error & { cause: unknown }).cause = {
+        message: "inner",
+        cause: { code: "EAI_AGAIN" },
+      };
+      expect(isUnreachableHostError(error)).toBe(true);
+    });
+
+    it("returns true when AggregateError-like errors array contains a match", () => {
+      const error = new Error("aggregate");
+      (error as Error & { errors: unknown[] }).errors = [
+        { message: "fetch failed" },
+      ];
+      expect(isUnreachableHostError(error)).toBe(true);
+    });
+
+    it("returns false for unrelated errors", () => {
+      expect(isUnreachableHostError(new Error("something else"))).toBe(false);
+    });
+
+    it("returns false for non-objects", () => {
+      expect(isUnreachableHostError(null)).toBe(false);
+      expect(isUnreachableHostError(undefined)).toBe(false);
+      expect(isUnreachableHostError("fetch failed")).toBe(false);
+    });
+
+    it("returns false for unknown cause codes", () => {
+      const error = new Error("oops");
+      (error as Error & { cause: unknown }).cause = { code: "ESOMETHING" };
+      expect(isUnreachableHostError(error)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Description

Display a graceful error if a PDS hostname cannot be reached, instead of `fetch failed`

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)

<img width="869" height="863" alt="Screenshot 2026-05-12 at 12 21 14 AM" src="https://github.com/user-attachments/assets/f3f73f17-7c61-46de-adb5-b6d9ac52642a" />


## Type of Change
<!-- Mark relevant options with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements