### PR TITLE
Fix 2FA bug on migration resume + extra logging to debug 2FA issues

### DIFF
--- a/app/sessions.server.ts
+++ b/app/sessions.server.ts
@@ -30,6 +30,7 @@ export type SessionData = {
   handle_origin?: string;
   handle_dest?: string;
   password_origin?: string;
+  password_dest?: string;
   pds_dest?: string;
   did_exists_in_dest?: boolean;
   did_active_in_dest?: boolean;

--- a/app/util/process-state.ts
+++ b/app/util/process-state.ts
@@ -81,8 +81,9 @@ const handleOriginLoginWith2FA = async (
     session.set("did", result.did);
     session.set("atp_origin_session", result.atp_origin_session);
 
-    // At this point, we no longer need the origin password
+    // At this point, we no longer need the origin password or the 2FA flag
     session.set("password_origin", undefined);
+    session.set("require_2fa_code", false);
 
     return result;
   } catch (e) {
@@ -198,6 +199,7 @@ export const processState = async (
         session.set("do_journey", state.do_journey);
         session.set("handle_dest", undefined);
         session.set("email", undefined);
+        session.set("require_2fa_code", false);
 
         //initialize the origin PDS to bluesky
         session.set("pds_origin", "https://bsky.social");

--- a/app/util/process-state.ts
+++ b/app/util/process-state.ts
@@ -52,15 +52,19 @@ const handleOriginLoginWith2FA = async (
     handle_origin = session.get("handle_origin") ?? handle_origin;
     password_origin = session.get("password_origin") ?? password_origin;
 
-    log.info("User session retrieved from first sign-in attempt, handle: ", handle_origin);
+    log.info(
+      `[${context}] 2FA retry: using session origin creds. ` +
+      `pds=${pds_origin}, handle=${handle_origin}, password present=${Boolean(password_origin)}`
+    );
   } else {
-    log.info("User session before update, handle: ", session.get("handle_origin") ?? "not set");
+    log.info(
+      `[${context}] First attempt: persisting origin creds to session. ` +
+      `prev_handle=${session.get("handle_origin")} -> new_handle=${handle_origin}`
+    );
 
     session.set("pds_origin", pds_origin);
     session.set("handle_origin", handle_origin);
     session.set("password_origin", password_origin);
-
-    log.info("User session saved from form, handle: ", handle_origin);
   }
 
   try {
@@ -85,7 +89,13 @@ const handleOriginLoginWith2FA = async (
     log.error(`Error during origin login for ${context}: `, e);
 
     if (e instanceof AuthFactorTokenRequiredError) {
-      log.info("2FA code required for origin login, prompting user to enter 2FA code");
+      log.info(
+        `[${context}] 2FA code required by origin PDS. ` +
+        `Persisted in session: handle_origin=${session.get("handle_origin")}, ` +
+        `password_origin present=${Boolean(session.get("password_origin"))}, ` +
+        `handle_dest=${session.get("handle_dest")}, ` +
+        `password_dest present=${Boolean(session.get("password_dest"))}`
+      );
       session.set("require_2fa_code", true);
       session.flash(
         "error",
@@ -146,6 +156,7 @@ export const processState = async (
     session.set("email", undefined);
     session.set("user_recover_key", undefined);
     session.set("password_origin", undefined);
+    session.set("password_dest", undefined);
 
     // state flags
     session.set("require_2fa_code", false);
@@ -339,6 +350,34 @@ export const processState = async (
       case STAGES.RESUME_MIGRATION: {
         const isMissingBlobsJourney = state.do_journey === "missing-blobs";
         const journeyContext = isMissingBlobsJourney ? "missing blobs recovery" : "migration resume";
+
+        // Persist dest credentials before attempting origin login, so they
+        // survive the 2FA retry where the form only submits the 2FA code.
+        const is2faAttempt = session.get("require_2fa_code") ?? false;
+        log.info(
+          `[${journeyContext}] Entering login stage. is2faAttempt=${is2faAttempt}. ` +
+          `Form dest creds: handle=${data.get("northsky-handle")}, ` +
+          `password present=${Boolean(data.get("northsky-password"))}. ` +
+          `Session dest creds: handle=${session.get("handle_dest")}, ` +
+          `password present=${Boolean(session.get("password_dest"))}`
+        );
+
+        if (!is2faAttempt) {
+          session.set("handle_dest", data.get("northsky-handle") as string);
+          session.set("password_dest", (data.get("northsky-password") as string) ?? "");
+          log.info(
+            `[${journeyContext}] First attempt: persisted dest creds to session. ` +
+            `handle_dest=${session.get("handle_dest")}, ` +
+            `password_dest present=${Boolean(session.get("password_dest"))}`
+          );
+        } else {
+          log.info(
+            `[${journeyContext}] 2FA retry: keeping previously-persisted dest creds. ` +
+            `handle_dest=${session.get("handle_dest")}, ` +
+            `password_dest present=${Boolean(session.get("password_dest"))}`
+          );
+        }
+
         const loginResult = await handleOriginLoginWith2FA(session, data, journeyContext);
 
         if (!loginResult) {
@@ -360,14 +399,24 @@ export const processState = async (
         log = logger.withDid(did);
         log.info(`Resume flow origin login successful! DID ${did}, exists in destination PDS: ${didExists}, active: ${didActive}`);
 
-        //Get dest handle and password from form
-        const handle_dest = data.get("northsky-handle") as string;
-        const password_dest = (data.get("northsky-password") as string) ?? "";
+        // Read dest handle and password from session
+        const handle_dest = session.get("handle_dest") as string;
+        const password_dest = session.get("password_dest") ?? "";
 
-        // Save dest handle to form in case it's changed somehow
-        session.set("handle_dest", handle_dest);
+        log.info(
+          `[${journeyContext}] Calling loginDest: ` +
+          `handle_dest=${handle_dest}, ` +
+          `password_dest present=${Boolean(password_dest)}`
+        );
 
-        log.info(`Attempting to log in user to destination for ${journeyContext}. Handle: ${handle_dest}`);
+        if (!handle_dest || handle_dest.length === 0) {
+          log.error(
+            `[${journeyContext}] handle_dest is empty before loginDest! ` +
+            `is2faAttempt=${is2faAttempt}, ` +
+            `form handle=${data.get("northsky-handle")}, ` +
+            `session handle=${session.get("handle_dest")}`
+          );
+        }
         const { token_dest, atp_dest_session } = await loginDest({
           pds_dest: state.pds_dest ?? "https://northsky.social",
           handle_dest,
@@ -376,6 +425,9 @@ export const processState = async (
 
         session.set("token_dest", token_dest);
         session.set("atp_dest_session", atp_dest_session);
+
+        // Dest password no longer needed after successful login
+        session.set("password_dest", undefined);
 
         if (isMissingBlobsJourney) {
           await sendDiscordMessage(`Missing blobs recovery started for account [**${handle_dest}**](<https://bsky.app/profile/${did}>) (${did})`);


### PR DESCRIPTION
## Description

Fixes an issue where the Northsky handle is lost from the app context when resuming a migration, if the origin account has 2FA enabled.

Also adds additional logging for better debugging of 2FA-related issues.

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<!-- Add before/after screenshots, GIFs, or key log snippets -->

## Type of Change
<!-- Mark relevant options with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements