### PR TITLE
Update tab title with `(!)` alert on interaction neeed

### DIFF
--- a/app/routes/failed.tsx
+++ b/app/routes/failed.tsx
@@ -2,6 +2,10 @@ import { data } from "react-router";
 import { getSession, commitSession } from "../sessions.server";
 import type { Route } from "./+types";
 
+export function meta(_: Route.MetaArgs): ReturnType<Route.MetaFunction> {
+  return [{ title: "Migration failed" }];
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const session = await getSession(request.headers.get("Cookie"));
 

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -25,6 +25,10 @@ import { logger } from "~/util/logger";
 import { BaseAppError } from "~/errors";
 import { checkPdsHealth } from "~/actions";
 
+export function meta(_: Route.MetaArgs): ReturnType<Route.MetaFunction> {
+  return [{ title: "Migrate to Northsky!" }];
+}
+
 export async function action({ request }: Route.ActionArgs) {
   const session = await getSession(request.headers.get("Cookie"));
   const path = parsePath(request.url);

--- a/app/routes/success.tsx
+++ b/app/routes/success.tsx
@@ -2,6 +2,10 @@ import { data } from "react-router";
 import { getSession, commitSession } from "../sessions.server";
 import type { Route } from "./+types";
 
+export function meta(_: Route.MetaArgs): ReturnType<Route.MetaFunction> {
+  return [{ title: "Migration complete!" }];
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const session = await getSession(request.headers.get("Cookie"));
   return data(

--- a/app/screens/add-rotation-key.client.tsx
+++ b/app/screens/add-rotation-key.client.tsx
@@ -13,9 +13,11 @@ import { useCallback, useState } from "react";
 import { Secp256k1Keypair } from "@atproto/crypto";
 import "@1password/save-button";
 import { logger } from "~/util/logger";
+import { useAttentionAlert } from "~/util/use-attention-alert";
 
 export default function AddRotationKeyScreen({ state }: ScreenProps) {
   const fetcher = useFetcher();
+  useAttentionAlert();
   const [didKeyWizard, setDidKeyWizard] = useState(false);
   const modalClose = useCallback(
     async (keypair: Secp256k1Keypair) => {

--- a/app/screens/done-migration.tsx
+++ b/app/screens/done-migration.tsx
@@ -7,9 +7,11 @@ import nsOtherAccount from "../assets/nsOtherAccount.png";
 import type { ScreenProps } from "~/util/stages";
 
 import { useFetcher } from "react-router";
+import { useAttentionAlert } from "~/util/use-attention-alert";
 
 export default function MigrationDoneScreen({ state }: ScreenProps) {
   const fetcher = useFetcher();
+  useAttentionAlert();
   return (
     <>
       <fetcher.Form method="post" style={{ width: "100%" }}>

--- a/app/screens/failed-migration.tsx
+++ b/app/screens/failed-migration.tsx
@@ -1,8 +1,10 @@
 import { Heading, Text, VStack } from "@chakra-ui/react";
 import melted_clock from "../assets/melted.jpg";
 import type { ScreenProps } from "~/util/stages";
+import { useAttentionAlert } from "~/util/use-attention-alert";
 
 export default function FailedMigrationScreen({ state }: ScreenProps) {
+  useAttentionAlert();
   return (
     <>
       <VStack mb="5" width="100%">

--- a/app/screens/missing-blobs-done.tsx
+++ b/app/screens/missing-blobs-done.tsx
@@ -1,9 +1,11 @@
 import { Heading, Text, Button, VStack, Center } from "@chakra-ui/react";
 import type { ScreenProps } from "~/util/stages";
 import { useFetcher } from "react-router";
+import { useAttentionAlert } from "~/util/use-attention-alert";
 
 export default function MissingBlobsDoneScreen({ state }: ScreenProps) {
   const fetcher = useFetcher();
+  useAttentionAlert();
   return (
     <fetcher.Form method="post" style={{ width: "100%" }}>
       <VStack mb="5" width="100%">

--- a/app/util/use-attention-alert.ts
+++ b/app/util/use-attention-alert.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+/**
+ * Use the browser's native Page Visibility API to alert
+ * the user that there's new activity on the page and we need
+ * their attention, useful after long-running migration steps.
+ *
+ * While the tab is hidden (Page Visibility API), the document title is
+ * prefixed with a marker so the browser tab visually flags an update. The
+ * original title is restored as soon as the user focuses the tab or the
+ * component unmounts.
+ */
+export function useAttentionAlert(): void {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const originalTitle = document.title;
+    const flaggedTitle = `(!) ${originalTitle}`;
+
+    const applyFlag = () => {
+      if (document.hidden && document.title !== flaggedTitle) {
+        document.title = flaggedTitle;
+      }
+    };
+
+    const clearFlag = () => {
+      if (document.title === flaggedTitle) {
+        document.title = originalTitle;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        applyFlag();
+      } else {
+        clearFlag();
+      }
+    };
+
+    // If the tab is already hidden when we mount, flag immediately.
+    if (document.hidden) {
+      applyFlag();
+    }
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      clearFlag();
+    };
+  }, []);
+}

--- a/app/util/use-attention-alert.ts
+++ b/app/util/use-attention-alert.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { logger } from "~/util/logger";
 
 /**
  * Use the browser's native Page Visibility API to alert
@@ -14,20 +15,31 @@ export function useAttentionAlert(): void {
   useEffect(() => {
     if (typeof document === "undefined") return;
 
+    const safe = <T>(fn: () => T): T | undefined => {
+      try {
+        return fn();
+      } catch (e) {
+        logger.warn("useAttentionAlert: ignoring error", e);
+        return undefined;
+      }
+    };
+
     const originalTitle = document.title;
     const flaggedTitle = `(!) ${originalTitle}`;
 
-    const applyFlag = () => {
-      if (document.hidden && document.title !== flaggedTitle) {
-        document.title = flaggedTitle;
-      }
-    };
+    const applyFlag = () =>
+      safe(() => {
+        if (document.hidden && document.title !== flaggedTitle) {
+          document.title = flaggedTitle;
+        }
+      });
 
-    const clearFlag = () => {
-      if (document.title === flaggedTitle) {
-        document.title = originalTitle;
-      }
-    };
+    const clearFlag = () =>
+      safe(() => {
+        if (document.title === flaggedTitle) {
+          document.title = originalTitle;
+        }
+      });
 
     const onVisibilityChange = () => {
       if (document.hidden) {
@@ -42,10 +54,17 @@ export function useAttentionAlert(): void {
       applyFlag();
     }
 
-    document.addEventListener("visibilitychange", onVisibilityChange);
+    const added = safe(() => {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+      return true;
+    });
 
     return () => {
-      document.removeEventListener("visibilitychange", onVisibilityChange);
+      if (added) {
+        safe(() =>
+          document.removeEventListener("visibilitychange", onVisibilityChange)
+        );
+      }
       clearFlag();
     };
   }, []);


### PR DESCRIPTION
## Description

It's possible for a user with a long migration process (e.g. many blobs) to leave the migration tab unattended, and not get any visual cue that an action is needed from them.

This change adds a small `(!)` alert to the tab title after the automated migration steps, to signal to the user that the tab has new content.

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<!-- Add before/after screenshots, GIFs, or key log snippets -->

## Type of Change
<!-- Mark relevant options with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements