### PR TITLE
Validate origin PDS is reachable on service token request

### DIFF
--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -181,6 +181,55 @@ async function refreshAgents(
   return { destResumeAgent, originResumeAgent };
 }
 
+/**
+ * Verify that a given origin PDS URL is reachable and responds like
+ * a valid PDS.
+ * @param pds_origin The URL of the origin PDS to check
+ * @throws LoginError if the PDS is unreachable or does not respond as expected
+ */
+export async function verifyOriginPdsReachable(pds_origin: string): Promise<void> {
+  let describeRes: Response;
+  try {
+    const describeUrl = new URL(
+      "/xrpc/com.atproto.server.describeServer",
+      pds_origin
+    ).toString();
+    describeRes = await f(describeUrl, { method: "GET" });
+  } catch (e) {
+    if (isUnreachableHostError(e)) {
+      logger.warn(`Unable to reach origin PDS at ${pds_origin} during describeServer`, e);
+    } else {
+      logger.warn(`Unexpected error calling describeServer for ${pds_origin}`, e);
+    }
+    throw new LoginError(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS);
+  }
+
+  if (!describeRes.ok) {
+    logger.warn(
+      `describeServer for origin PDS ${pds_origin} returned status ${describeRes.status}`
+    );
+    throw new LoginError(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS);
+  }
+
+  let describeBody: { did?: string } | null = null;
+  try {
+    describeBody = (await describeRes.json()) as { did?: string } | null;
+  } catch (parseError) {
+    logger.warn(
+      `describeServer for origin PDS ${pds_origin} returned invalid JSON`,
+      parseError
+    );
+    throw new LoginError(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS);
+  }
+
+  if (!describeBody || typeof describeBody.did !== "string" || !describeBody.did) {
+    logger.warn(
+      `describeServer for origin PDS ${pds_origin} did not return a did`
+    );
+    throw new LoginError(XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS);
+  }
+}
+
 export async function loginOrigin({
   pds_origin,
   handle_origin,
@@ -206,6 +255,9 @@ export async function loginOrigin({
     logger.warn(`loginOrigin called without a password (handle: ${handle_origin})`);
     throw new LoginError("Invalid password");
   }
+
+  // Sanity-checking the origin PDS is reachable
+  await verifyOriginPdsReachable(pds_origin);
 
   // Login to origin PDS
   let agentSessionData;
@@ -418,6 +470,9 @@ export async function createDestAccount(
     const pds_dest_hostname: string = 'northsky.social';
     const aud = `did:web:${pds_dest_hostname.match("localhost") ? "localhost" : pds_dest_hostname}`;
 
+    // Sanity-checking the origin PDS is reachable before getting the service token
+    await verifyOriginPdsReachable(pds_origin);
+
     // Generate service token
     log.info(`Requesting service token from ${MIGRATOR_BACKEND}/service-auth (aud: ${aud}, pds_host: ${serviceEndpoint})`);
     const res = await f(`${MIGRATOR_BACKEND}/service-auth`, {
@@ -439,7 +494,8 @@ export async function createDestAccount(
         `Service token request failed: status=${res.status} statusText=${res.statusText}, body=${nonOkBody}}`
       );
       throw new LoginError(
-        `Unexpected response when requesting service token; please contact support with error: ${res.statusText}`
+        `Unexpected response when requesting service token; please contact support with error: ${res.statusText}`,
+        "Unexpected"
       );
     }
 
@@ -449,7 +505,8 @@ export async function createDestAccount(
         `Service token response missing token field (status=${res.status})"}`
       );
       throw new LoginError(
-        `Invalid service token received; please contact support with error: ${res.statusText}`
+        `Invalid service token received; please contact support with error: ${res.statusText}`,
+        "Unexpected"
       );
     }
     log.info("Service token received successfully");

--- a/test/unit/actions.test.ts
+++ b/test/unit/actions.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { checkIfDidExistsInDest } from "~/actions";
+import { checkIfDidExistsInDest, verifyOriginPdsReachable } from "~/actions";
+import { LoginError } from "~/errors";
+import { XRPC_ERROR_MESSAGES } from "~/util/xrpc-errors";
 
 vi.mock("~/util/logger", () => ({
   logger: {
     withDid: () => ({ warn: vi.fn() }),
+    warn: vi.fn(),
   },
 }));
 
@@ -72,5 +75,115 @@ describe("checkIfDidExistsInDest", () => {
     const result = await checkIfDidExistsInDest(testDid, testPdsDest);
 
     expect(result).toEqual({ didExists: false, didActive: false });
+  });
+});
+
+describe("verifyOriginPdsReachable", () => {
+  const pdsOrigin = "https://pds.example.com";
+  const describeUrl = `${pdsOrigin}/xrpc/com.atproto.server.describeServer`;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("resolves when describeServer returns 200 with a non-empty did", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ did: "did:web:pds.example.com" }),
+    } as Response);
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = mockFetch.mock.calls[0];
+    expect(String(calledUrl)).toBe(describeUrl);
+    expect(calledInit).toMatchObject({ method: "GET" });
+  });
+
+  it("throws an Expected LoginError when the response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => ({}),
+    } as Response);
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toMatchObject({
+      name: "LoginError",
+      message: XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS,
+      errorType: "Expected",
+    });
+  });
+
+  it("throws an Expected LoginError when the JSON body is invalid", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("invalid json");
+      },
+    } as unknown as Response);
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toBeInstanceOf(
+      LoginError
+    );
+  });
+
+  it("throws an Expected LoginError when the response body has no did", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ availableUserDomains: [".example.com"] }),
+    } as Response);
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toMatchObject({
+      message: XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS,
+      errorType: "Expected",
+    });
+  });
+
+  it("throws an Expected LoginError when the did is an empty string", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ did: "" }),
+    } as Response);
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toBeInstanceOf(
+      LoginError
+    );
+  });
+
+  it("throws an Expected LoginError when the did is not a string", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ did: 123 }),
+    } as Response);
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toBeInstanceOf(
+      LoginError
+    );
+  });
+
+  it("throws an Expected LoginError when fetch rejects (network failure)", async () => {
+    mockFetch.mockRejectedValueOnce(
+      Object.assign(new Error("fetch failed"), {
+        cause: { code: "ENOTFOUND" },
+      })
+    );
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toMatchObject({
+      message: XRPC_ERROR_MESSAGES.UNREACHABLE_ORIGIN_PDS,
+      errorType: "Expected",
+    });
+  });
+
+  it("throws an Expected LoginError on an unexpected synchronous error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(verifyOriginPdsReachable(pdsOrigin)).rejects.toBeInstanceOf(
+      LoginError
+    );
   });
 });


### PR DESCRIPTION
## Description

Fast-follow to show a graceful error before getting a service token if the origin PDS is not found.

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<!-- Add before/after screenshots, GIFs, or key log snippets -->

## Type of Change
<!-- Mark relevant options with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements