### PR TITLE
Export repo action as background job (async)

### DIFF
--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -614,8 +614,8 @@ export async function exportRepo(
     false
   );
 
-  // export repo
-  const res = await f(`${MIGRATOR_BACKEND}/export-repo`, {
+  // start export repo job
+  const res = await f(`${MIGRATOR_BACKEND}/jobs/export-repo`, {
     method: "post",
     body: JSON.stringify({
       pds_host: pds_origin,
@@ -632,7 +632,9 @@ export async function exportRepo(
     throw new MigrationError(message);
   }
 
-  return { ok: true };
+  const { job_id } = await res.json<{ job_id: string }>();
+
+  return { job_id };
 }
 
 export async function importRepo(

--- a/app/sessions.server.ts
+++ b/app/sessions.server.ts
@@ -47,12 +47,16 @@ export type SessionData = {
   email?: string;
   user_recover_key?: string | null;
   export_progress?: BackgroundJobProgress | null;
+  export_repo_progress?: BackgroundJobProgress | null;
   upload_progress?: BackgroundJobProgress | null;
   export_job_id?: string | null;
+  export_repo_job_id?: string | null;
   import_job_id?: string | null;
   export_job_failures?: number;
+  export_repo_job_failures?: number;
   import_job_failures?: number;
   last_export_check?: number;
+  last_export_repo_check?: number;
   last_import_check?: number;
   handle_not_available?: boolean | null;
   password_mismatch?: boolean | null;

--- a/app/util/jobs.ts
+++ b/app/util/jobs.ts
@@ -11,12 +11,12 @@ const JOB_CHECK_INTERVAL_MS = 2000;
  * Configuration for a background job (export or import)
  */
 export type BackgroundJobConfig = {
-  jobIdKey: "export_job_id" | "import_job_id";
-  progressKey: "export_progress" | "upload_progress";
-  lastCheckKey: "last_export_check" | "last_import_check";
-  failuresKey: "export_job_failures" | "import_job_failures";
-  completedKey: "exportedBlobs" | "importedBlobs";
-  jobKind: "ExportBlobs" | "UploadBlobs";
+  jobIdKey: "export_job_id" | "import_job_id" | "export_repo_job_id";
+  progressKey: "export_progress" | "upload_progress" | "export_repo_progress";
+  lastCheckKey: "last_export_check" | "last_import_check" | "last_export_repo_check";
+  failuresKey: "export_job_failures" | "import_job_failures" | "export_repo_job_failures";
+  completedKey: "exportedBlobs" | "importedBlobs" | "exportedRepo";
+  jobKind: "ExportBlobs" | "UploadBlobs" | "ExportRepo";
   startJob: (state: SessionData, backend: string) => Promise<{ job_id?: string } | undefined>;
 };
 

--- a/app/util/process-state.ts
+++ b/app/util/process-state.ts
@@ -177,6 +177,10 @@ export const processState = async (
     session.set("user_recover_key", undefined);
     session.set("password_origin", undefined);
     session.set("password_dest", undefined);
+    session.set("export_repo_job_id", undefined);
+    session.set("export_repo_progress", undefined);
+    session.set("export_repo_job_failures", undefined);
+    session.set("last_export_repo_check", undefined);
 
     // state flags
     session.set("require_2fa_code", false);
@@ -290,10 +294,15 @@ export const processState = async (
       }
 
       case STAGES.EXPORT_REPO_ORIGIN: {
-        const { ok } = await exportRepo(state, migratorBackend);
-        if (ok) {
-          session.set("exportedRepo", ok);
-        }
+        await processBackgroundJobStage(state, session, {
+          jobIdKey: "export_repo_job_id",
+          progressKey: "export_repo_progress",
+          lastCheckKey: "last_export_repo_check",
+          failuresKey: "export_repo_job_failures",
+          completedKey: "exportedRepo",
+          jobKind: "ExportRepo",
+          startJob: exportRepo,
+        }, migratorBackend);
         break;
       }
 

--- a/test/unit/jobs.test.ts
+++ b/test/unit/jobs.test.ts
@@ -55,6 +55,16 @@ const uploadConfig: BackgroundJobConfig = {
   startJob: vi.fn(),
 };
 
+const exportRepoConfig: BackgroundJobConfig = {
+  jobIdKey: "export_repo_job_id",
+  progressKey: "export_repo_progress",
+  lastCheckKey: "last_export_repo_check",
+  failuresKey: "export_repo_job_failures",
+  completedKey: "exportedRepo",
+  jobKind: "ExportRepo",
+  startJob: vi.fn(),
+};
+
 const BACKEND = "https://migrator.example";
 
 const buildState = (overrides: Partial<SessionData> = {}): SessionData => ({
@@ -191,5 +201,59 @@ describe("processBackgroundJobStage", () => {
     await processBackgroundJobStage(state, session, uploadConfig, BACKEND);
 
     expect(session.get("importedBlobs")).toBe(true);
+  });
+
+  it("starts export-repo job and stores job id when none exists", async () => {
+    vi.mocked(exportRepoConfig.startJob).mockResolvedValueOnce({ job_id: "repo-job-1" });
+
+    const state = buildState({
+      import_job_id: undefined,
+      export_repo_job_id: undefined,
+    });
+    const session = buildSession(state);
+
+    await processBackgroundJobStage(state, session, exportRepoConfig, BACKEND);
+
+    expect(exportRepoConfig.startJob).toHaveBeenCalledWith(state, BACKEND);
+    expect(session.get("export_repo_job_id")).toBe("repo-job-1");
+  });
+
+  it("stores export-repo API progress and marks exportedRepo on success", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          created_at: 0,
+          finished_at: 0,
+          id: "repo-job-1",
+          kind: "ExportRepo",
+          progress: {
+            invalid_blobs: 1,
+            successful_blobs: 1,
+            total: 1,
+          },
+          started_at: 0,
+          status: "success",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const state = buildState({
+      import_job_id: undefined,
+      export_repo_job_id: "repo-job-1",
+      last_export_repo_check: 0,
+      exportedRepo: false,
+    });
+    const session = buildSession(state);
+
+    await processBackgroundJobStage(state, session, exportRepoConfig, BACKEND);
+
+    expect(session.get("export_repo_progress")).toEqual({
+      invalid_blobs: 1,
+      successful_blobs: 1,
+      total: 1,
+    });
+    expect(session.get("exportedRepo")).toBe(true);
+    expect(session.get("had_invalid_blobs")).toBeUndefined();
   });
 });

--- a/test/unit/process-state.test.ts
+++ b/test/unit/process-state.test.ts
@@ -39,9 +39,11 @@ vi.mock("~/actions", () => ({
 
 import {
   checkIfDidExistsInDest,
+  exportRepo,
   loginOrigin,
   loginDest,
 } from "~/actions";
+import { processBackgroundJobStage } from "~/util/jobs";
 import { processState } from "~/util/process-state";
 import type { SessionData, SessionFlashData } from "~/sessions.server";
 import type { Session } from "react-router";
@@ -80,6 +82,7 @@ describe("processState", () => {
     vi.mocked(loginOrigin).mockReset();
     vi.mocked(loginDest).mockReset();
     vi.mocked(checkIfDidExistsInDest).mockReset();
+    vi.mocked(processBackgroundJobStage).mockReset();
 
     vi.mocked(loginOrigin).mockResolvedValue({
       token_origin: "tok-origin",
@@ -96,6 +99,7 @@ describe("processState", () => {
       didExists: true,
       didActive: true,
     });
+    vi.mocked(processBackgroundJobStage).mockResolvedValue(undefined);
   });
 
   it("missing-blobs journey proceeds with loginDest even when dest account is already active", async () => {
@@ -135,5 +139,34 @@ describe("processState", () => {
     expect(loginDest).not.toHaveBeenCalled();
     expect(session.get("did_active_in_dest")).toBe(true);
     expect(session.get("token_dest")).toBeUndefined();
+  });
+
+  it("routes EXPORT_REPO_ORIGIN through processBackgroundJobStage with export-repo config", async () => {
+    const session = buildSession({
+      do_journey: "migrate",
+      inviteCode: "invite123",
+      hasBackup: true,
+      token_origin: "tok-origin",
+      did: "did:plc:alice",
+      pds_origin: "https://bsky.social",
+      token_dest: "tok-dest",
+      handle_dest: "alice.northsky.social",
+      pds_dest: "https://northsky.social",
+      exportedRepo: false,
+    });
+
+    await processState(session, new FormData(), "https://migrator.example.com");
+
+    expect(processBackgroundJobStage).toHaveBeenCalledTimes(1);
+    const config = vi.mocked(processBackgroundJobStage).mock.calls[0]?.[2];
+    expect(config).toMatchObject({
+      jobIdKey: "export_repo_job_id",
+      progressKey: "export_repo_progress",
+      lastCheckKey: "last_export_repo_check",
+      failuresKey: "export_repo_job_failures",
+      completedKey: "exportedRepo",
+      jobKind: "ExportRepo",
+    });
+    expect(config?.startJob).toBe(exportRepo);
   });
 });


### PR DESCRIPTION
## Description

Move the export repo step from sync (request-response) to async (job polling), to prevent long-running operations from failing when CAR files are too large and/or origin PDS instances restrict their export speeds.

Reuses the background polling logic from our download/upload blob steps.

Related back-end change: https://github.com/NorthskySocial/pds-migration-backend/pull/109

## Related Issues
<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Screenshots / Logs (if applicable)
<!-- Add before/after screenshots, GIFs, or key log snippets -->

## Type of Change
<!-- Mark relevant options with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [x] Test improvements